### PR TITLE
Fixed argc check to allow third argument

### DIFF
--- a/interface/cli.cpp
+++ b/interface/cli.cpp
@@ -65,7 +65,7 @@ void CLI::processFile() {
 }
 
 bool CLI::checkInput() {
-	if (argc > 1 && argc < 3) return true;
+	if (argc > 1 && argc <= 3) return true;
 	printUsage();
 	return false;
 }


### PR DESCRIPTION
It was impossible to to add the third OUTPUTDIRECTORY argument
because CLI::checkInput() was checking for an argc less than
three.